### PR TITLE
Initial updates for Ubuntu 16

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -22,7 +22,7 @@ class mongodb::repository {
     'Ubuntu': {
       include ::apt
       apt::source { 'mongodb':
-        location    => 'http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2',
+        location    => 'http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2',
         release     => 'multiverse',
         repos       => '',
         key         => { 'server' => 'hkp://keyserver.ubuntu.com:80', 'id' =>  '42F3E95A2C4F08279C4960ADD68FA50FEA312927' },


### PR DESCRIPTION
Changed release name to 'xenial' to reflect Ubuntu 16.04. Currently hard coded value.